### PR TITLE
Removed nta git submodule, replaced with CMake commands to manually clon...

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "nupic.core"]
-	path = nta
-	url = git://github.com/numenta/nupic.core.git

--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,2 +1,3 @@
+# Default nupic.core dependencies (override in optional .nupic_modules)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
 NUPIC_CORE_COMMITISH = '90df8f1ef9eabda03695a9aa60c8029fe3540b9e'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 # --------------------------------------------------------------------------------------------------------------------------
 
 # nupic.core external git dependencies
-SET(NUPIC_CORE_REMOTE "https://github.com/numenta/nupic.core.git"
+set(NUPIC_CORE_REMOTE "https://github.com/numenta/nupic.core.git"
     CACHE
     STRING
     "nupic.core remote repository")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,16 +22,6 @@
 #   David Ragazzi (@DavidRagazzi): Full conversion and adaptation from Autotools scripts
 # --------------------------------------------------------------------------------------------------------------------------
 
-# nupic.core external git dependencies
-set(NUPIC_CORE_REMOTE "https://github.com/numenta/nupic.core.git"
-    CACHE
-    STRING
-    "nupic.core remote repository")
-set(NUPIC_CORE_COMMITISH "90df8f1ef9eabda03695a9aa60c8029fe3540b9e"
-    CACHE
-    STRING
-    "nupic.core commit")
-
 ############################################################################################################################
 ###                                                                                                                      ###
 ###  Macros                                                                                                              ###
@@ -257,25 +247,25 @@ macro(generate_swig_module name output_dir sub_dir swig_flags cxx_flags extra_so
 endmacro()
 
 # This macro generates imported library from submodules
-macro(generate_submodule_library name submodule_dir extra_cxxflags extra_linkflags)
+macro(generate_submodule_library name submodule_dir extra_cxxflags extra_linkflags remote commitish)
 
-  # checkout nupic.core
+  # checkout git dependency
   if (NOT EXISTS ${submodule_dir})
-    execute_process(COMMAND git clone ${NUPIC_CORE_REMOTE} ${submodule_dir})
+    execute_process(COMMAND git clone ${remote} ${submodule_dir})
     if(NOT EXIT_CODE EQUAL 0)
-      message(FATAL_ERROR "Unable to clone ${NUPIC_CORE_REMOTE} into ${submodule_dir}")
+      message(FATAL_ERROR "Unable to clone ${remote} into ${submodule_dir}")
     endif()
   else()
-    execute_process(COMMAND git fetch ${NUPIC_CORE_REMOTE}
+    execute_process(COMMAND git fetch ${remote}
                     WORKING_DIRECTORY ${submodule_dir})
     if(NOT EXIT_CODE EQUAL 0)
-      message(FATAL_ERROR "Unable to fetch ${NUPIC_CORE_REMOTE}")
+      message(FATAL_ERROR "Unable to fetch ${remote}")
     endif()
   endif()
-  execute_process(COMMAND git checkout ${NUPIC_CORE_COMMITISH}
+  execute_process(COMMAND git checkout ${commitish}
                   WORKING_DIRECTORY ${submodule_dir})
   if(NOT EXIT_CODE EQUAL 0)
-    message(FATAL_ERROR "Unable to checkout ${NUPIC_CORE_COMMITISH} in ${submodule_dir}")
+    message(FATAL_ERROR "Unable to checkout ${commitish} in ${submodule_dir}")
   endif()
 
   # Build and set external libraries
@@ -733,7 +723,9 @@ generate_static_library(${LIB_STATIC_SUPPORT} "${PROJECT_SOURCE_DIR}/lang/py/sup
 # LibNupicCore
 #
 set(LIB_STATIC_NUPICCORE nupic_core)
-generate_submodule_library(${LIB_STATIC_NUPICCORE} "${REPOSITORY_DIR}/nta" "-DNTA_PYTHON_SUPPORT=${PYTHON_VERSION}" "")
+set(NUPIC_CORE_REMOTE "git://github.com/numenta/nupic.core.git" CACHE STRING "nupic.core remote repository")
+set(NUPIC_CORE_COMMITISH "90df8f1ef9eabda03695a9aa60c8029fe3540b9e" CACHE STRING "nupic.core commit")
+generate_submodule_library(${LIB_STATIC_NUPICCORE} "${REPOSITORY_DIR}/nta" "-DNTA_PYTHON_SUPPORT=${PYTHON_VERSION}" "" "${NUPIC_CORE_REMOTE}" "${NUPIC_CORE_COMMITISH}")
 
 #
 # HtmTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@
 ###                                                                                                                      ###
 ############################################################################################################################
 
-# This function read variables from a file in the following format:
+# This function reads variables from a file in the following format:
 # FOO = 'bar'
 function (read_variable_from_file file_content variable value)
   set(${value} PARENT_SCOPE)
@@ -48,7 +48,13 @@ macro (show_config_variable variable value)
   message(STATUS "  ${variable} = ${value}")
 endmacro()
 
-# This macro gets variables from the config files
+# This macro gets variables from the optional .nupic_config file located in
+# project root, falling back to $HOME if one is not found.  If a .nupic_config
+# file is found in either location, the values override the default
+# .nupic_modules file checked into the repository.  As a developer, if your
+# changes depend on the values in .nupic_config, be sure to apply those changes
+# in .nupic_modules and submit a GitHub Pull Request to share the changes
+# upstream
 function (get_config_variable variable value default)
   set(${value} PARENT_SCOPE)
 
@@ -777,7 +783,7 @@ generate_static_library(${LIB_STATIC_SUPPORT} "${PROJECT_SOURCE_DIR}/lang/py/sup
 #
 # LibNupicCore
 #
-# Put content from module config file into variables
+# Put content from module config (.nupic_modules) file into variables
 file(READ "${REPOSITORY_DIR}/.nupic_modules" MODULES_FILE_CONTENT)
 read_variable_from_file("${MODULES_FILE_CONTENT}" "NUPIC_CORE_REMOTE" NUPIC_CORE_REMOTE)
 read_variable_from_file("${MODULES_FILE_CONTENT}" "NUPIC_CORE_COMMITISH" NUPIC_CORE_COMMITISH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,8 @@ macro(generate_submodule_library name submodule_dir extra_cxxflags extra_linkfla
       message(FATAL_ERROR "Unable to clone ${NUPIC_CORE_REMOTE} into ${submodule_dir}")
     endif()
   else()
-    execute_process(COMMAND git fetch ${NUPIC_CORE_REMOTE})
+    execute_process(COMMAND git fetch ${NUPIC_CORE_REMOTE}
+                    WORKING_DIRECTORY ${submodule_dir})
     if(NOT EXIT_CODE EQUAL 0)
       message(FATAL_ERROR "Unable to fetch ${NUPIC_CORE_REMOTE}")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,19 +251,22 @@ macro(generate_submodule_library name submodule_dir extra_cxxflags extra_linkfla
 
   # checkout git dependency
   if (NOT EXISTS ${submodule_dir})
-    execute_process(COMMAND git clone ${remote} ${submodule_dir})
+    execute_process(COMMAND git clone ${remote} ${submodule_dir}
+                    RESULT_VARIABLE EXIT_CODE)
     if(NOT EXIT_CODE EQUAL 0)
       message(FATAL_ERROR "Unable to clone ${remote} into ${submodule_dir}")
     endif()
   else()
     execute_process(COMMAND git fetch ${remote}
-                    WORKING_DIRECTORY ${submodule_dir})
+                    WORKING_DIRECTORY ${submodule_dir}
+                    RESULT_VARIABLE EXIT_CODE)
     if(NOT EXIT_CODE EQUAL 0)
       message(FATAL_ERROR "Unable to fetch ${remote}")
     endif()
   endif()
   execute_process(COMMAND git checkout ${commitish}
-                  WORKING_DIRECTORY ${submodule_dir})
+                  WORKING_DIRECTORY ${submodule_dir}
+                  RESULT_VARIABLE EXIT_CODE)
   if(NOT EXIT_CODE EQUAL 0)
     message(FATAL_ERROR "Unable to checkout ${commitish} in ${submodule_dir}")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,15 @@
 #   David Ragazzi (@DavidRagazzi): Full conversion and adaptation from Autotools scripts
 # --------------------------------------------------------------------------------------------------------------------------
 
+# nupic.core external git dependencies
+SET(NUPIC_CORE_REMOTE "https://github.com/numenta/nupic.core.git"
+    CACHE
+    STRING
+    "nupic.core remote repository")
+set(NUPIC_CORE_COMMITISH "90df8f1ef9eabda03695a9aa60c8029fe3540b9e"
+    CACHE
+    STRING
+    "nupic.core commit")
 
 ############################################################################################################################
 ###                                                                                                                      ###
@@ -68,7 +77,7 @@ endmacro()
 
 # These macros copy all source directories after the configuration is done
 # Note: If NTAX_DEVELOPER_BUILD is set, copy is optimized (directories are linked, and files are not copied if the modification time of the target is more recent).
-macro (copy suffix src dst)  
+macro (copy suffix src dst)
   if("$ENV{NTAX_DEVELOPER_BUILD}" STREQUAL "1")
     message(STATUS "Linking from '${src}' to '${dst}'")
     get_filename_component(dst_dir ${dst} PATH)
@@ -250,6 +259,24 @@ endmacro()
 # This macro generates imported library from submodules
 macro(generate_submodule_library name submodule_dir extra_cxxflags extra_linkflags)
 
+  # checkout nupic.core
+  if (NOT EXISTS ${submodule_dir})
+    execute_process(COMMAND git clone ${NUPIC_CORE_REMOTE} ${submodule_dir})
+    if(NOT EXIT_CODE EQUAL 0)
+      message(FATAL_ERROR "Unable to clone ${NUPIC_CORE_REMOTE} into ${submodule_dir}")
+    endif()
+  else()
+    execute_process(COMMAND git fetch ${NUPIC_CORE_REMOTE})
+    if(NOT EXIT_CODE EQUAL 0)
+      message(FATAL_ERROR "Unable to fetch ${NUPIC_CORE_REMOTE}")
+    endif()
+  endif()
+  execute_process(COMMAND git checkout ${NUPIC_CORE_COMMITISH}
+                  WORKING_DIRECTORY ${submodule_dir})
+  if(NOT EXIT_CODE EQUAL 0)
+    message(FATAL_ERROR "Unable to checkout ${NUPIC_CORE_COMMITISH} in ${submodule_dir}")
+  endif()
+
   # Build and set external libraries
   message(STATUS "Building '${name}' library...")
 
@@ -306,7 +333,7 @@ set(PROJECT_BUILD_TEMP_DIR "" CACHE STRING "Temporary dir")
 
 #
 # Sets default locations.
-# 
+#
 # Default directories structure is:
 #
 # ~/../repository (root directory with repository downloaded from internet)
@@ -343,16 +370,6 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BUILD_RELEA
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BUILD_RELEASE_DIR}/bin)
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BUILD_TEMP_DIR}/lib)
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BUILD_TEMP_DIR}/obj)
-
-#
-# Update repository submodules
-#
-execute_process(COMMAND git submodule update --init
-                WORKING_DIRECTORY ${REPOSITORY_DIR}
-                RESULT_VARIABLE EXIT_CODE)
-if(NOT EXIT_CODE EQUAL 0)
-  message(FATAL_ERROR "Updating submodules within ${REPOSITORY_DIR} failed.")
-endif()
 
 #
 # Set OS flags
@@ -404,7 +421,7 @@ elseif(LINUX)
   if(${NTA_PLATFORM_ARCH} MATCHES "64")
     set(NTA_PLATFORM_OS "linux64")
     set(NTA_PLATFORM_CXXFLAGS "${NTA_PLATFORM_CXXFLAGS} -m64")
-  else()    
+  else()
     set(NTA_PLATFORM_OS "linux32")
     set(NTA_PLATFORM_CXXFLAGS "${NTA_PLATFORM_CXXFLAGS} -ffloat-store")
   endif()
@@ -705,7 +722,7 @@ set(NTA_CXXFLAGS "${NTA_CXXFLAGS_BASE} ${NTA_CXXFLAGS_OPTIMIZATION}")
 # LibSupport
 #
 # lang/py/support must be built before nta, but lang must be built after nta.
-# This is due to the fact that both nta/pynode and lang/py/net_internal depend 
+# This is due to the fact that both nta/pynode and lang/py/net_internal depend
 # on lang/py/support and lang/py/engine_internal depends on nta.
 #
 set(LIB_STATIC_SUPPORT support)
@@ -765,7 +782,7 @@ if(NTA_PYTHON_SUPPORT)
   # there is nothing Python-obvious about this name, so it may
   # conflict with libraries we generate for other target languages
   # in the future.
-  # (The list of sources also includes the swig interface files, even 
+  # (The list of sources also includes the swig interface files, even
   # though they're not used to compile, just to get the dependencies right.)
   # They will linked in the "real" C++ library that the bindings are wrapping.
 
@@ -872,28 +889,28 @@ copy_file(${PROJECT_SOURCE_DIR}/lang/py/engine/__init__.py ${PYTHON_SITE_PACKAGE
 #
 # Tests
 #
-add_custom_target(tests_run 
-                  COMMAND python ${PROJECT_BUILD_RELEASE_DIR}/bin/run_tests.py 
+add_custom_target(tests_run
+                  COMMAND python ${PROJECT_BUILD_RELEASE_DIR}/bin/run_tests.py
                   COMMENT "Python tests")
 
-add_custom_target(tests_run_all 
+add_custom_target(tests_run_all
                   COMMAND python ${PROJECT_BUILD_RELEASE_DIR}/bin/run_tests.py --all
                   COMMENT "Python tests + swarming (requires DB)")
 
-add_custom_target(tests_pyhtm 
+add_custom_target(tests_pyhtm
                   COMMAND ${PROJECT_BUILD_RELEASE_DIR}/bin/testpyhtm
                   COMMENT "Basic tests in Python")
 
-add_custom_target(tests_cpphtm 
+add_custom_target(tests_cpphtm
                   COMMAND ${PROJECT_BUILD_RELEASE_DIR}/bin/testcpphtm
                   COMMENT "Basic tests in C++")
 
-add_custom_target(tests_everything 
+add_custom_target(tests_everything
                   COMMAND ${PROJECT_BUILD_RELEASE_DIR}/bin/testeverything
                   COMMENT "C++ unit tests")
 
 # Tests_all just calls other targets
-add_custom_target(tests_all 
+add_custom_target(tests_all
                   DEPENDS tests_run
                   DEPENDS tests_pyhtm
                   DEPENDS tests_cpphtm
@@ -903,7 +920,7 @@ add_custom_target(tests_all
 #
 # Clean
 #
-add_custom_target(distclean 
+add_custom_target(distclean
 		# Clean '/build/release' and build/temp
 		COMMAND ${CMAKE_COMMAND} -E remove_directory ${PROJECT_BUILD_RELEASE_DIR}
 		COMMAND ${CMAKE_COMMAND} -E remove_directory ${PROJECT_BUILD_TEMP_DIR}


### PR DESCRIPTION
...e,

fetch, and checkout nupic.core repository.  This also allows overriding the
defaults on the command line via NUPIC_CORE_REMOTE, for the remote repository
url, and NUPIC_CORE_COMMITISH, for the specific sha.